### PR TITLE
Test that we deal with garbage WEBVTT signatures.

### DIFF
--- a/tests/garbage-signature.vtt
+++ b/tests/garbage-signature.vtt
@@ -1,0 +1,1 @@
+garbage vtt file

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -134,3 +134,6 @@ check("tests/cue-settings-vertical.vtt", 10);
 check("tests/cue-settings-size.vtt", 11);
 check("tests/cue-settings-position.vtt", 11);
 check("tests/cue-settings-line-position.vtt", 15);
+// Can't check streaming as waiting for 7 characters before starting to process the file messes
+// the expected value up.
+checkAllAtOnce("tests/garbage-signature.vtt", 0, expect_fail("invalid signature 'garbage vtt file'"));

--- a/vtt.js
+++ b/vtt.js
@@ -200,7 +200,7 @@ WebVTTParser.prototype = {
   },
   flush: function () {
     var self = this;
-    if (self.state !== "ID") {
+    if (self.state !== "ID" && self.state !== "INITIAL") {
       // Synthesize the end of the current block.
       self.buffer += "\n\n";
       self.parse();


### PR DESCRIPTION
I've added a new condition to the flush function so that we don't
incorrectly try to synthesize the end of a WEBVTT signature.

@andreasgal does this look good to you? I've touched vtt.js so I wanted to get your feedback before landing.
