### PR TITLE
Add tests/util/cue2json.js for creating test-ready JSON from parsed cues

### DIFF
--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -4,29 +4,8 @@
 var path = require("path"),
     fs = require("fs"),
     util = require("./util"),
-    WebVTTParser = require("../").WebVTTParser;
-
-// This implements a minimum fake window object constructor that is sufficient
-// to test constructing a DOM Tree for cue content.
-function FakeWindow() {
-  this.DocumentFragment = function () {
-    function appendChild(node) {
-      this.childNodes = this.childNodes || [];
-      this.childNodes.push(node);
-      node.parentNode = this;
-    }
-    this.createElement = function(tagName) {
-      return { tagName: tagName, appendChild: appendChild };
-    };
-    this.createTextNode = function(text) {
-      return { textContent: text };
-    };
-    this.appendChild = appendChild;
-  };
-  this.ProcessingInstruction = function () {
-    return { };
-  };
-};
+    WebVTTParser = require("../").WebVTTParser,
+    FakeWindow = require("./util/fake-window.js");
 
 function parseTestList(testListPath) {
   var testArgs = fs.readFileSync(testListPath, "utf8").split("\n"),
@@ -75,16 +54,13 @@ function parseTestList(testListPath) {
   return testList;
 }
 
-// Filter
-
-
 function runTest(test) {
 
   // Set the parentNode value to unefined when trying to stringify the JSON.
   // Without this we will get a circular data structure which stringify will
   // not be able to handle.
   function filterJson(key, value) {
-    if (key == "parentNode") 
+    if (key == "parentNode")
       return undefined;
     return value;
   }
@@ -97,7 +73,7 @@ function runTest(test) {
       t.equal(JSON.stringify(json.domTree),
               JSON.stringify(WebVTTParser.convertCueToDOMTree(new FakeWindow(),
                                                               vtt.cues[0]),
-                            filterJson),
+                             filterJson),
               "DOM tree should be equal.");
       t.end();
     };

--- a/tests/util/cue2json.js
+++ b/tests/util/cue2json.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+
+if (process.argv.length !== 3) {
+  console.error("Error: missing .vtt filename to process");
+  console.error("Usage: cue2json <filename>");
+  process.exit(1);
+}
+
+var filename = process.argv[2],
+    WebVTTParser = require("../..").WebVTTParser,
+    FakeWindow = require("./fake-window.js"),
+    parser = new WebVTTParser(),
+    cues = [];
+
+parser.oncue = function(cue) {
+  cues.push(cue);
+};
+parser.parse(require("fs").readFileSync(filename, "utf8"));
+parser.flush();
+
+// Set the parentNode value to unefined when trying to stringify the JSON.
+// Without this we will get a circular data structure which stringify will
+// not be able to handle.
+function filterJson(key, value) {
+  if (key == "parentNode")
+    return undefined;
+  return value;
+}
+
+function printCue(cue) {
+  cue.domTree = WebVTTParser.convertCueToDOMTree(new FakeWindow(), cue);
+  console.log(JSON.stringify(cue, filterJson, 2));
+}
+
+// Single cue
+if (cues.length === 1) {
+  printCue(cues[0]);
+}
+// Array of cues
+else {
+  console.log("[");
+  for (var i = 0; i < cues.length - 1; i++) {
+    printCue(cues[i]);
+    console.log(",");
+  }
+
+  printCue(cues[cues.length-1]);
+  console.log("]");
+}

--- a/tests/util/fake-window.js
+++ b/tests/util/fake-window.js
@@ -1,0 +1,20 @@
+// This implements a minimum fake window object constructor that is sufficient
+// to test constructing a DOM Tree for cue content.
+module.exports = function FakeWindow() {
+  this.DocumentFragment = function () {
+    function appendChild(node) {
+      this.childNodes = this.childNodes || [];
+      this.childNodes.push(node);
+      node.parentNode = this;
+    }
+    this.createElement = function(tagName) {
+      return { tagName: tagName, appendChild: appendChild };
+    };
+    this.createTextNode = function(text) {
+      return { textContent: text };
+    };
+    this.appendChild = appendChild;
+  };
+  this.ProcessingInstruction = function () {
+  };
+};


### PR DESCRIPTION
Looking at Rick's new test harness, it seemed to me like it would be nice if you didn't have to hand-write that JSON.  This adds a node script that you can use to get JSON output suitable for a test run.  You use it like this:

```
$ ./tests/util/cue2json.js some-file.vtt > some-file.json
```

Hopefully this will let Rick go faster.

Rick, can you give this a try and land if you're happy with it?  I can fix if you hit issues.
