### PR TITLE
Switch to underscore's isEqual for equality tests, use patched difflet.

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -1,8 +1,8 @@
 var WebVTTParser = require("..").WebVTTParser,
     FakeWindow = require("./fake-window.js"),
     assert = Object.create(require("assert")),
-    deepEqual = require("deep-equal"),
-    difflet = require("difflet")({ indent: 2 }),
+    deepEqual = require("underscore").isEqual,
+    difflet = require("difflet")({ indent: 2, deepEqual: deepEqual }),
     fs = require("fs"),
     path = require("path");
 

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "grunt-cli": "~0.1.9",
     "grunt-contrib-jshint": "~0.6.0",
     "mocha": "~1.12.0",
-    "deep-equal": "~0.0.0",
-    "difflet": "~0.2.6"
+    "difflet": "git://github.com/humphd/difflet.git#714b82706ad39d75275a886aeff637df5097626f",
+    "underscore": "~1.5.1"
   },
   "main": "vtt.js",
   "scripts": {


### PR DESCRIPTION
This moves to use a strict equality check in our deepEqual.  I've also patched difflet to allow for passing in the same deepEqual function (I sent a PR to him https://github.com/substack/difflet/pull/15 as well).  We'll have to fixup the 80 vs "80" type issues in a lot of tests if we land this, since so much fails in existing json files.
