### PR TITLE
Add names of students to AUTHORS who wrote tests we've ported from previous WebVTT work.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,14 @@ here, you may add your name and, optionally, email address in the
 appropriate place.
 
 Andreas Gal <gal@mozilla.com>
+Rick Eyre <rick.eyre@hotmail.com>
+David Humphrey <david.humphrey@senecacollege.ca>
+Ali Al Dallal <ali@alicoding.com>
+Edwin Lim <limed3@gmail.com>
+Michael Afidchao <mdafidchao@learn.senecac.on.ca>
+Shayan Ahmad <szahmad@learn.senecac.on.ca>
+Jordan Raffoul <raffoul.jordan@gmail.com>
+Vince Lee <vince.lee.lien@gmail.com>
+Kyle Barnhart <kyle@barnhart.ca>
+Mandeep Garg <mkgarg1@learn.senecac.on.ca>
+Dale Karp <me@dale.io>


### PR DESCRIPTION
I'd like to recognize the work of former students, who wrote tests for the old code that Rick has ported over to this repo.  Each of the names added to AUTHORS is someone who has either contributed directly here, or contributed a test we've used from the old repo (I've copied their name/email from the AUTHORS file).
