### PR TITLE
Fix region scroll setting to accept the value "up".

### DIFF
--- a/tests/integration/regions.json
+++ b/tests/integration/regions.json
@@ -8,7 +8,7 @@
       "regionAnchorY": 100,
       "viewportAnchorX": 10,
       "viewportAnchorY": 100,
-      "scroll": "none"
+      "scroll": "up"
     },
     {
       "id": "bill",
@@ -18,7 +18,7 @@
       "regionAnchorY": 100,
       "viewportAnchorX": 90,
       "viewportAnchorY": 100,
-      "scroll": "none"
+      "scroll": "up"
     }
   ],
   "cues": [

--- a/tests/regions/scroll/correct.json
+++ b/tests/regions/scroll/correct.json
@@ -8,7 +8,7 @@
       "regionAnchorY": 100,
       "viewportAnchorX": 0,
       "viewportAnchorY": 100,
-      "scroll": "none"
+      "scroll": "up"
     }
   ],
   "cues": []

--- a/tests/regions/scroll/test.js
+++ b/tests/regions/scroll/test.js
@@ -7,7 +7,7 @@ describe("regions/scroll tests", function(){
     assert.jsonEqual("regions/scroll/bogus-value.vtt", "regions/scroll/bad-scroll.json");
   });
 
-  it.skip("correct.vtt", function(){
+  it("correct.vtt", function(){
     assert.jsonEqual("regions/scroll/correct.vtt", "regions/scroll/correct.json");
   });
 

--- a/vtt.js
+++ b/vtt.js
@@ -346,7 +346,7 @@ WebVTTParser.prototype = {
           region.get(k + "Y", anchor.get("y"));
           break;
         case "scroll":
-          region.alt(k, v, "up");
+          region.alt(k, v, ["up"]);
           break;
         }
       }, /=/, /\s/);


### PR DESCRIPTION
We were incorrectly passing the value "up" into the settings.alt
function instead of passing an array with the value "up" in it which
is what is needed.

Fixes #54.
