### PR TITLE
Fix infinite loop bug on blank-file.vtt.

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -107,7 +107,7 @@ assert.jsonEqual = function(vttFilename, jsonFilename, message) {
   }
 
   // Now check again using streaming with different chunk sizes
-  while (--size) {
+  while (--size >= 0) {
     vtt = getVttData(data, size);
     if (!deepEqual(vtt, json)) {
       return fail("parsing file with streaming, chunk size=" + size);

--- a/tests/file-layout/test.js
+++ b/tests/file-layout/test.js
@@ -7,7 +7,7 @@ describe("file-layout tests", function(){
     assert.jsonEqual("file-layout/blank-file-with-bom.vtt", "file-layout/no-output.json");
   });
 
-  it.skip("blank-file.vtt", function(){
+  it("blank-file.vtt", function(){
     assert.jsonEqual("file-layout/blank-file.vtt", "file-layout/no-output.json");
   });
 


### PR DESCRIPTION
Problem was that we weren't explicitly checking size >= 0 on
streaming tests. Which means that on tests with an initial size of
0 we would keep looping indefinitely.
