### PR TITLE
Fix bug where newline before WEBVTT was being parsed.

### DIFF
--- a/tests/file-layout/test.js
+++ b/tests/file-layout/test.js
@@ -40,7 +40,7 @@ describe("file-layout tests", function(){
     assert.jsonEqual("file-layout/many-comments.vtt", "file-layout/many-comments.json");
   });  
 
-  it.skip("newline-before-webvtt.vtt", function(){
+  it("newline-before-webvtt.vtt", function(){
     assert.jsonEqual("file-layout/newline-before-webvtt.vtt", "file-layout/no-output.json");
   });
 


### PR DESCRIPTION
The problem here was that we were consuming the newline on the
first call to parse and therefore on subsequent calls to parse
the parser has no idea that there was a newline there to begin
with.

Issue #60.
