### PR TITLE
Fix regions without newlines to be parsed.

### DIFF
--- a/tests/regions/test.js
+++ b/tests/regions/test.js
@@ -15,7 +15,7 @@ describe("region tests", function(){
     assert.jsonEqual("regions/line-break.vtt", "regions/bad-region.json");
   });
 
-  it.skip("no-line-break.vtt", function(){
+  it("no-line-break.vtt", function(){
     assert.jsonEqual("regions/no-line-break.vtt", "regions/no-line-break.json");
   });
 

--- a/vtt.js
+++ b/vtt.js
@@ -498,8 +498,8 @@ WebVTTParser.prototype = {
   },
   flush: function () {
     var self = this;
-    if (self.cue) {
-      // Synthesize the end of the current cue.
+    if (self.cue || self.state === "HEADER") {
+      // Synthesize the end of the current cue or region.
       self.buffer += "\n\n";
       self.parse();
     }


### PR DESCRIPTION
We need to synthesize the end of the current cue or region when
calling flush().

Fixes issue #48.
