### PR TITLE
Fix test harness to work with BOM files.

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -11,6 +11,10 @@ function fixTestPath(filename) {
   return path.join(__dirname, "..", "tests", filename);
 }
 
+function synthesizeBOM(data) {
+  return data.replace(/^\uFEFF/, "\xEF\xBB\xBF");
+}
+
 // Set the parentNode value to undefined when trying to stringify the JSON.
 // Without this we will get a circular data structure which stringify will
 // not be able to handle.
@@ -62,7 +66,7 @@ function parse(filename, usePathUnchanged) {
     filename = fixTestPath(filename);
   }
 
-  return _parse(fs.readFileSync(filename, "utf8"));
+  return _parse(synthesizeBOM(fs.readFileSync(filename, "utf8")));
 }
 
 function getVttData(data, chunkAt) {
@@ -97,7 +101,7 @@ assert.jsonEqual = function(vttFilename, jsonFilename, message) {
     return assert.fail(vttFilename, jsonFilename, "Unable to open " + jsonFilename, "===");
   }
 
-  var data = fs.readFileSync(vttFilename, "utf8"),
+  var data = synthesizeBOM(fs.readFileSync(vttFilename, "utf8")),
       size = data.length;
 
   // First check that things work when parsing the file whole

--- a/tests/file-layout/test.js
+++ b/tests/file-layout/test.js
@@ -60,7 +60,7 @@ describe("file-layout tests", function(){
     assert.jsonEqual("file-layout/webvtt-tab.vtt", "file-layout/with-data.json");
   });
 
-  it.skip("webvtt-with-bom.vtt", function(){
+  it("webvtt-with-bom.vtt", function(){
     assert.jsonEqual("file-layout/webvtt-with-bom.vtt", "file-layout/with-data.json");
   });
 


### PR DESCRIPTION
We were failing on testing files with BOM characters in them
as node translates the BOM character to 0xFEFF when reading
it in. Solution was to replace 0xFEFF with the correct code
point sequence and pass that to the parser.

Fix issue #61.
