### PR TITLE
Add snap-to-lines flag to cue settings.

### DIFF
--- a/tests/cue-settings/align/bad-align.json
+++ b/tests/cue-settings/align/bad-align.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cue-settings/align/keyword-end.json
+++ b/tests/cue-settings/align/keyword-end.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "end"

--- a/tests/cue-settings/align/keyword-left.json
+++ b/tests/cue-settings/align/keyword-left.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "left"

--- a/tests/cue-settings/align/keyword-middle.json
+++ b/tests/cue-settings/align/keyword-middle.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cue-settings/align/keyword-right.json
+++ b/tests/cue-settings/align/keyword-right.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "right"

--- a/tests/cue-settings/align/keyword-start.json
+++ b/tests/cue-settings/align/keyword-start.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "start"

--- a/tests/cue-settings/line/bad-line.json
+++ b/tests/cue-settings/line/bad-line.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cue-settings/line/integer-value.json
+++ b/tests/cue-settings/line/integer-value.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": 42,
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cue-settings/line/large-integer-value.json
+++ b/tests/cue-settings/line/large-integer-value.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": 102041241024101120,
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cue-settings/line/negative-integer-value.json
+++ b/tests/cue-settings/line/negative-integer-value.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": -1208,
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cue-settings/line/negative-zeros.json
+++ b/tests/cue-settings/line/negative-zeros.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": 0,
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cue-settings/line/percent-value.json
+++ b/tests/cue-settings/line/percent-value.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": 42,
+        "snapToLines": false,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cue-settings/position/bad-position.json
+++ b/tests/cue-settings/position/bad-position.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cue-settings/position/percent-value.json
+++ b/tests/cue-settings/position/percent-value.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 42,
         "size": 100,
         "align": "middle"

--- a/tests/cue-settings/region/bad-region.json
+++ b/tests/cue-settings/region/bad-region.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cue-settings/region/valid.json
+++ b/tests/cue-settings/region/valid.json
@@ -7,6 +7,7 @@
         "region": "fred123a$@*&AS01a",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cue-settings/size/bad-size.json
+++ b/tests/cue-settings/size/bad-size.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cue-settings/size/percent-value.json
+++ b/tests/cue-settings/size/percent-value.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 42,
         "align": "middle"

--- a/tests/cue-settings/vertical/bad-vertical.json
+++ b/tests/cue-settings/vertical/bad-vertical.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cue-settings/vertical/correct-lr-keyword.json
+++ b/tests/cue-settings/vertical/correct-lr-keyword.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "lr",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cue-settings/vertical/correct-rl-keyword.json
+++ b/tests/cue-settings/vertical/correct-rl-keyword.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "rl",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cue-times/fractions.json
+++ b/tests/cue-times/fractions.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cue-times/max-spot-digits.json
+++ b/tests/cue-times/max-spot-digits.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cue-times/max-spots-over-sixty.json
+++ b/tests/cue-times/max-spots-over-sixty.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cue-times/max-time-spots.json
+++ b/tests/cue-times/max-time-spots.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cue-times/minimum-spots-over-sixty.json
+++ b/tests/cue-times/minimum-spots-over-sixty.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cue-times/minimum-time-spots.json
+++ b/tests/cue-times/minimum-time-spots.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cue-times/mismatched-time-spots.json
+++ b/tests/cue-times/mismatched-time-spots.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cue-times/with-data.json
+++ b/tests/cue-times/with-data.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/bold/not-closed.json
+++ b/tests/cuetext/bold/not-closed.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/bold/with-annotation.json
+++ b/tests/cuetext/bold/with-annotation.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/bold/with-closing-span.json
+++ b/tests/cuetext/bold/with-closing-span.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/bold/with-subclass.json
+++ b/tests/cuetext/bold/with-subclass.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/bold/with-two-subclasses.json
+++ b/tests/cuetext/bold/with-two-subclasses.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/class/not-closed.json
+++ b/tests/cuetext/class/not-closed.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/class/with-annotation.json
+++ b/tests/cuetext/class/with-annotation.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/class/with-closing-span.json
+++ b/tests/cuetext/class/with-closing-span.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/class/with-subclass.json
+++ b/tests/cuetext/class/with-subclass.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/class/with-two-subclasses.json
+++ b/tests/cuetext/class/with-two-subclasses.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/escape-characters/amp.json
+++ b/tests/cuetext/escape-characters/amp.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/escape-characters/gt.json
+++ b/tests/cuetext/escape-characters/gt.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/escape-characters/incorrect.json
+++ b/tests/cuetext/escape-characters/incorrect.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/escape-characters/lrm.json
+++ b/tests/cuetext/escape-characters/lrm.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/escape-characters/lt.json
+++ b/tests/cuetext/escape-characters/lt.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/escape-characters/nbsp.json
+++ b/tests/cuetext/escape-characters/nbsp.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/escape-characters/rlm.json
+++ b/tests/cuetext/escape-characters/rlm.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/format/double-line-break.json
+++ b/tests/cuetext/format/double-line-break.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/format/line-breaks.json
+++ b/tests/cuetext/format/line-breaks.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/format/long-line.json
+++ b/tests/cuetext/format/long-line.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/format/no-line-break.json
+++ b/tests/cuetext/format/no-line-break.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/format/no-newline-at-end.json
+++ b/tests/cuetext/format/no-newline-at-end.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/italic/not-closed.json
+++ b/tests/cuetext/italic/not-closed.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/italic/with-annotation.json
+++ b/tests/cuetext/italic/with-annotation.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/italic/with-closing-span.json
+++ b/tests/cuetext/italic/with-closing-span.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/italic/with-subclass.json
+++ b/tests/cuetext/italic/with-subclass.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/italic/with-two-subclasses.json
+++ b/tests/cuetext/italic/with-two-subclasses.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/lang/no-end-gt.json
+++ b/tests/cuetext/lang/no-end-gt.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/lang/not-closed.json
+++ b/tests/cuetext/lang/not-closed.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/lang/with-annotation.json
+++ b/tests/cuetext/lang/with-annotation.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/lang/with-closing-span.json
+++ b/tests/cuetext/lang/with-closing-span.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/lang/with-no-annotation.json
+++ b/tests/cuetext/lang/with-no-annotation.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/lang/with-subclass.json
+++ b/tests/cuetext/lang/with-subclass.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/lang/with-two-subclasses.json
+++ b/tests/cuetext/lang/with-two-subclasses.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/ruby/basic.json
+++ b/tests/cuetext/ruby/basic.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/ruby/rt-no-end-tag.json
+++ b/tests/cuetext/ruby/rt-no-end-tag.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/ruby/rt-no-ruby-tag.json
+++ b/tests/cuetext/ruby/rt-no-ruby-tag.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/ruby/ruby-rt-no-end-tag.json
+++ b/tests/cuetext/ruby/ruby-rt-no-end-tag.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/ruby/with-annotation.json
+++ b/tests/cuetext/ruby/with-annotation.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/ruby/with-closing-span.json
+++ b/tests/cuetext/ruby/with-closing-span.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/ruby/with-subclass.json
+++ b/tests/cuetext/ruby/with-subclass.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/ruby/with-two-subclasses.json
+++ b/tests/cuetext/ruby/with-two-subclasses.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/tag-format/bogus-span-name.json
+++ b/tests/cuetext/tag-format/bogus-span-name.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/tag-format/end-tag-no-gt.json
+++ b/tests/cuetext/tag-format/end-tag-no-gt.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/tag-format/incorrect-close-tag-order.json
+++ b/tests/cuetext/tag-format/incorrect-close-tag-order.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/tag-format/no-closing-gt.json
+++ b/tests/cuetext/tag-format/no-closing-gt.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/tag-format/no-start-tag.json
+++ b/tests/cuetext/tag-format/no-start-tag.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/tag-format/start-tag-missing-gt.json
+++ b/tests/cuetext/tag-format/start-tag-missing-gt.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/timestamp/basic.json
+++ b/tests/cuetext/timestamp/basic.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/timestamp/nested.json
+++ b/tests/cuetext/timestamp/nested.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/timestamp/no-end-gt.json
+++ b/tests/cuetext/timestamp/no-end-gt.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/timestamp/non-digit.json
+++ b/tests/cuetext/timestamp/non-digit.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/timestamp/out-of-cue-range.json
+++ b/tests/cuetext/timestamp/out-of-cue-range.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/timestamp/space-after-lt.json
+++ b/tests/cuetext/timestamp/space-after-lt.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/timestamp/space-before-gt.json
+++ b/tests/cuetext/timestamp/space-before-gt.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/underline/not-closed.json
+++ b/tests/cuetext/underline/not-closed.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/underline/with-annotation.json
+++ b/tests/cuetext/underline/with-annotation.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/underline/with-closing-span.json
+++ b/tests/cuetext/underline/with-closing-span.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/underline/with-subclass.json
+++ b/tests/cuetext/underline/with-subclass.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/underline/with-two-subclasses.json
+++ b/tests/cuetext/underline/with-two-subclasses.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/voice/no-end-gt.json
+++ b/tests/cuetext/voice/no-end-gt.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/voice/not-closed.json
+++ b/tests/cuetext/voice/not-closed.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/voice/with-annotation.json
+++ b/tests/cuetext/voice/with-annotation.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/voice/with-closing-span.json
+++ b/tests/cuetext/voice/with-closing-span.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/voice/with-subclass.json
+++ b/tests/cuetext/voice/with-subclass.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/cuetext/voice/with-two-subclasses.json
+++ b/tests/cuetext/voice/with-two-subclasses.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/file-layout/cue-spacing.json
+++ b/tests/file-layout/cue-spacing.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"
@@ -28,6 +29,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"
@@ -49,6 +51,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/file-layout/fail-bad-utf8.json
+++ b/tests/file-layout/fail-bad-utf8.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 50,
         "align": "end"

--- a/tests/file-layout/many-comments.json
+++ b/tests/file-layout/many-comments.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"
@@ -28,6 +29,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/file-layout/with-data.json
+++ b/tests/file-layout/with-data.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/integration/arrows.json
+++ b/tests/integration/arrows.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/integration/cue-content-class.json
+++ b/tests/integration/cue-content-class.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 50,
         "align": "start"

--- a/tests/integration/cue-content.json
+++ b/tests/integration/cue-content.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 50,
         "align": "start"

--- a/tests/integration/cue-identifier.json
+++ b/tests/integration/cue-identifier.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"
@@ -28,6 +29,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/integration/not-only-nested-cues.json
+++ b/tests/integration/not-only-nested-cues.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"
@@ -28,6 +29,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/integration/one-line-comment.json
+++ b/tests/integration/one-line-comment.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"
@@ -28,6 +29,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/integration/only-nested-cues.json
+++ b/tests/integration/only-nested-cues.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"
@@ -28,6 +29,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"
@@ -49,6 +51,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"
@@ -70,6 +73,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"
@@ -91,6 +95,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"
@@ -112,6 +117,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/integration/regions.json
+++ b/tests/integration/regions.json
@@ -28,6 +28,7 @@
         "region": "fred",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "left"
@@ -49,6 +50,7 @@
         "region": "bill",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "right"
@@ -70,6 +72,7 @@
         "region": "fred",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "left"
@@ -91,6 +94,7 @@
         "region": "bill",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "right"
@@ -112,6 +116,7 @@
         "region": "fred",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "left"
@@ -133,6 +138,7 @@
         "region": "fred",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "left"

--- a/tests/integration/spec-example.json
+++ b/tests/integration/spec-example.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"
@@ -35,6 +36,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"
@@ -63,6 +65,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"
@@ -91,6 +94,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"
@@ -119,6 +123,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"
@@ -147,6 +152,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"
@@ -175,6 +181,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"
@@ -203,6 +210,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"
@@ -231,6 +239,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 50,
         "align": "end"
@@ -259,6 +268,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 50,
         "align": "start"
@@ -287,6 +297,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 50,
         "align": "end"
@@ -315,6 +326,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 50,
         "align": "start"
@@ -343,6 +355,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/tests/simple.json
+++ b/tests/simple.json
@@ -7,6 +7,7 @@
         "region": "",
         "vertical": "",
         "line": "auto",
+        "snapToLines": true,
         "position": 50,
         "size": 100,
         "align": "middle"

--- a/vtt.js
+++ b/vtt.js
@@ -55,9 +55,12 @@ Settings.prototype = {
     if (/^\d+%$/.test(v)) {
       v = v.replace("%", "");
       v = frac ? (v * 1) : (v | 0);
-      if (v >= 0 && v <= 100)
+      if (v >= 0 && v <= 100) {
         this.set(k, parseInt(v, 10));
+        return true;
+      }
     }
+    return false;
   }
 };
 
@@ -100,7 +103,7 @@ function parseCue(input, cue) {
         break;
       case "line":
         settings.integer(k, v);
-        settings.percent(k, v);
+        settings.percent(k, v) ? settings.set("snapToLines", false) : null;
         settings.alt(k, v, ["auto"]);
         break;
       case "position":
@@ -118,6 +121,7 @@ function parseCue(input, cue) {
       region: settings.get("region", ""),
       vertical: settings.get("vertical", ""),
       line: settings.get("line", "auto"),
+      snapToLines: settings.get("snapToLines", true),
       position: settings.get("position", 50),
       size: settings.get("size", 100),
       align: settings.get("align", "middle")


### PR DESCRIPTION
The spec specifies that a snap-to-lines flag is to be set when
the line cue setting is a percentage. This is to differentiate
between whether or not line is an integer or a percentage.

Issue #15.
