### PR TITLE
Check for U+FEFF instead of UTF8 BOM sequence.

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -11,10 +11,6 @@ function fixTestPath(filename) {
   return path.join(__dirname, "..", "tests", filename);
 }
 
-function synthesizeBOM(data) {
-  return data.replace(/^\uFEFF/, "\xEF\xBB\xBF");
-}
-
 // Set the parentNode value to undefined when trying to stringify the JSON.
 // Without this we will get a circular data structure which stringify will
 // not be able to handle.
@@ -66,7 +62,7 @@ function parse(filename, usePathUnchanged) {
     filename = fixTestPath(filename);
   }
 
-  return _parse(synthesizeBOM(fs.readFileSync(filename, "utf8")));
+  return _parse(fs.readFileSync(filename, "utf8"));
 }
 
 function getVttData(data, chunkAt) {
@@ -101,7 +97,7 @@ assert.jsonEqual = function(vttFilename, jsonFilename, message) {
     return assert.fail(vttFilename, jsonFilename, "Unable to open " + jsonFilename, "===");
   }
 
-  var data = synthesizeBOM(fs.readFileSync(vttFilename, "utf8")),
+  var data = fs.readFileSync(vttFilename, "utf8"),
       size = data.length;
 
   // First check that things work when parsing the file whole

--- a/vtt.js
+++ b/vtt.js
@@ -270,7 +270,7 @@ function parseContent(window, input) {
   return fragment;
 }
 
-const BOM = "\xEF\xBB\xBF";
+const BOM = "\uFEFF";
 const WEBVTT = "WEBVTT";
 
 function WebVTTParser() {


### PR DESCRIPTION
Since the parser works with a buffer that has been decoded it should
really be looking for the BOM character as an U+FEFF code point.

While working on getting #55 working I realized that we fixed this incorrectly in #71.
