### PR TITLE
Fix bug where only the first escape character would be escaped.

### DIFF
--- a/tests/cuetext/escape-characters/test.js
+++ b/tests/cuetext/escape-characters/test.js
@@ -31,4 +31,8 @@ describe("cuetext/escape-characters tests", function(){
     assert.jsonEqual("cuetext/escape-characters/rlm.vtt", "cuetext/escape-characters/rlm.json");
   });
 
+  it("together.vtt", function(){
+    assert.jsonEqual("cuetext/escape-characters/together.vtt", "cuetext/escape-characters/together.json");
+  });
+
 });

--- a/tests/cuetext/escape-characters/together.json
+++ b/tests/cuetext/escape-characters/together.json
@@ -1,0 +1,27 @@
+{
+  "regions": [],
+  "cues": [
+    {
+      "id": "",
+      "settings": {
+        "region": "",
+        "vertical": "",
+        "line": "auto",
+        "snapToLines": true,
+        "position": 50,
+        "size": 100,
+        "align": "middle"
+      },
+      "startTime": "000000000",
+      "endTime": "000002000",
+      "content": "Some text &lt; &amp;&gt; &lt; &nb&nbsp; &am&lt; &rlm;&lr&lrm; other stuff.",
+      "domTree": {
+        "childNodes": [
+          {
+            "textContent": "Some text < &> < &nb\u00a0 &am< \u200f&lr\u200e other stuff."
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/cuetext/escape-characters/together.vtt
+++ b/tests/cuetext/escape-characters/together.vtt
@@ -1,0 +1,4 @@
+WEBVTT
+
+00:00.000 --> 00:02.000
+Some text &lt; &amp;&gt; &lt; &nb&nbsp; &am&lt; &rlm;&lr&lrm; other stuff.

--- a/tests/integration/cue-content.json
+++ b/tests/integration/cue-content.json
@@ -29,6 +29,40 @@
           }
         ]
       }
+    },
+    {
+      "id": "",
+      "settings": {
+        "region": "escapes",
+        "vertical": "",
+        "line": 40,
+        "snapToLines": false,
+        "position": 50,
+        "size": 50,
+        "align": "start"
+      },
+      "startTime": "000034500",
+      "endTime": "000036500",
+      "content": "Random escapes &am&amp; other <i> stuff &gt; &l&lt;&rl&rlm;&lrm; </i>\nOh my! &gt;",
+      "domTree": {
+        "childNodes": [
+          {
+            "textContent": "Random escapes &am& other "
+          },
+          {
+            "tagName": "i",
+            "localName": "i",
+            "childNodes": [
+              {
+                "textContent": " stuff > &l<&rl\u200f\u200e "
+              }
+            ]
+          },
+          {
+            "textContent": "\nOh my! >"
+          }
+        ]
+      }
     }
   ]
 }

--- a/tests/integration/cue-content.vtt
+++ b/tests/integration/cue-content.vtt
@@ -2,3 +2,7 @@ WEBVTT
 
 00:32.500 --> 00:33.500 align:start size:50%
 <v Neil deGrasse Tyson><i>Laughs</i>
+
+00:34.500 --> 00:36.500 align:start size:50% line:40% region:escapes
+Random escapes &am&amp; other <i> stuff &gt; &l&lt;&rl&rlm;&lrm; </i>
+Oh my! &gt;

--- a/vtt.js
+++ b/vtt.js
@@ -200,8 +200,8 @@ function parseContent(window, input) {
     return ESCAPE[e];
   }
   function unescape(s) {
-    while ((m = s.match(/^[^<&]*(&(amp|lt|gt|lrm|rlm|nbsp);)/)) !== null)
-      s = s.replace(m[1], unescape1);
+    while ((m = s.match(/&(amp|lt|gt|lrm|rlm|nbsp);/)))
+      s = s.replace(m[0], unescape1);
     return s;
   }
 


### PR DESCRIPTION
I wrote a new test for multiple escape characters on the same line and close together and found a bug where we weren't replacing escape sequences that occur after an &amp; or &lt;
