### PR TITLE
Update keyword-middle.vtt

### DIFF
--- a/tests/cue-settings/align/keyword-middle.vtt
+++ b/tests/cue-settings/align/keyword-middle.vtt
@@ -1,4 +1,4 @@
 WEBVTT
 
-00:00.000 --> 00:02.000 align:midde
+00:00.000 --> 00:02.000 align:middle
 Text


### PR DESCRIPTION
Don't know if the typo was on purpose, since the default value is 'middle' or if this was a mistake in the test
