### PR TITLE
Update element's local name and tag name to be to spec

### DIFF
--- a/tests/cuetext/class/not-closed.json
+++ b/tests/cuetext/class/not-closed.json
@@ -19,7 +19,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "c",
+            "localName": "span",
             "childNodes": [
               {
                 "textContent": "It's a blue apple tree!"

--- a/tests/cuetext/class/with-annotation.json
+++ b/tests/cuetext/class/with-annotation.json
@@ -19,7 +19,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "c",
+            "localName": "span",
             "childNodes": [
               {
                 "textContent": "No way!"

--- a/tests/cuetext/class/with-closing-span.json
+++ b/tests/cuetext/class/with-closing-span.json
@@ -19,7 +19,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "c",
+            "localName": "span",
             "childNodes": [
               {
                 "textContent": "This is awesome!"

--- a/tests/cuetext/class/with-subclass.json
+++ b/tests/cuetext/class/with-subclass.json
@@ -19,7 +19,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "c",
+            "localName": "span",
             "className": "first",
             "childNodes": [
               {

--- a/tests/cuetext/class/with-two-subclasses.json
+++ b/tests/cuetext/class/with-two-subclasses.json
@@ -19,7 +19,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "c",
+            "localName": "span",
             "className": "first loud",
             "childNodes": [
               {

--- a/tests/cuetext/lang/no-end-gt.json
+++ b/tests/cuetext/lang/no-end-gt.json
@@ -19,7 +19,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "lang",
+            "localName": "span",
             "lang": "en-Us It's a blue apple tree!"
           }
         ]

--- a/tests/cuetext/lang/not-closed.json
+++ b/tests/cuetext/lang/not-closed.json
@@ -19,7 +19,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "lang",
+            "localName": "span",
             "lang": "en-Us",
             "childNodes": [
               {

--- a/tests/cuetext/lang/with-annotation.json
+++ b/tests/cuetext/lang/with-annotation.json
@@ -19,7 +19,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "lang",
+            "localName": "span",
             "lang": "en-Us",
             "childNodes": [
               {

--- a/tests/cuetext/lang/with-closing-span.json
+++ b/tests/cuetext/lang/with-closing-span.json
@@ -19,7 +19,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "lang",
+            "localName": "span",
             "lang": "en-Us",
             "childNodes": [
               {

--- a/tests/cuetext/lang/with-no-annotation.json
+++ b/tests/cuetext/lang/with-no-annotation.json
@@ -19,7 +19,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "lang",
+            "localName": "span",
             "childNodes": [
               {
                 "textContent": "Hee!"

--- a/tests/cuetext/lang/with-subclass.json
+++ b/tests/cuetext/lang/with-subclass.json
@@ -19,7 +19,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "lang",
+            "localName": "span",
             "lang": "en-Us",
             "className": "first",
             "childNodes": [

--- a/tests/cuetext/lang/with-two-subclasses.json
+++ b/tests/cuetext/lang/with-two-subclasses.json
@@ -19,7 +19,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "lang",
+            "localName": "span",
             "lang": "en-Us",
             "className": "first loud",
             "childNodes": [

--- a/tests/cuetext/tag-format/end-tag-no-gt.json
+++ b/tests/cuetext/tag-format/end-tag-no-gt.json
@@ -19,7 +19,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "c",
+            "localName": "span",
             "childNodes": [
               {
                 "textContent": "This is "

--- a/tests/cuetext/tag-format/no-closing-gt.json
+++ b/tests/cuetext/tag-format/no-closing-gt.json
@@ -19,7 +19,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "c"
+            "localName": "span"
           }
         ]
       }

--- a/tests/cuetext/tag-format/start-tag-missing-gt.json
+++ b/tests/cuetext/tag-format/start-tag-missing-gt.json
@@ -19,7 +19,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "c",
+            "localName": "span",
             "className": "first"
           }
         ]

--- a/tests/cuetext/voice/no-end-gt.json
+++ b/tests/cuetext/voice/no-end-gt.json
@@ -19,7 +19,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "v",
+            "localName": "span",
             "title": "It's a blue apple tree!"
           }
         ]

--- a/tests/cuetext/voice/not-closed.json
+++ b/tests/cuetext/voice/not-closed.json
@@ -19,7 +19,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "v",
+            "localName": "span",
             "childNodes": [
               {
                 "textContent": "It's a blue apple tree!"

--- a/tests/cuetext/voice/with-annotation.json
+++ b/tests/cuetext/voice/with-annotation.json
@@ -19,7 +19,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "v",
+            "localName": "span",
             "title": "Mary",
             "childNodes": [
               {

--- a/tests/cuetext/voice/with-closing-span.json
+++ b/tests/cuetext/voice/with-closing-span.json
@@ -19,7 +19,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "v",
+            "localName": "span",
             "title": "Joe",
             "childNodes": [
               {

--- a/tests/cuetext/voice/with-subclass.json
+++ b/tests/cuetext/voice/with-subclass.json
@@ -19,7 +19,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "v",
+            "localName": "span",
             "title": "Joe",
             "className": "loud",
             "childNodes": [

--- a/tests/cuetext/voice/with-two-subclasses.json
+++ b/tests/cuetext/voice/with-two-subclasses.json
@@ -19,7 +19,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "v",
+            "localName": "span",
             "title": "Joe",
             "className": "first loud",
             "childNodes": [

--- a/tests/integration/cue-content-class.json
+++ b/tests/integration/cue-content-class.json
@@ -19,7 +19,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "v",
+            "localName": "span",
             "title": "Mary",
             "className": "loud",
             "childNodes": [

--- a/tests/integration/cue-content.json
+++ b/tests/integration/cue-content.json
@@ -19,7 +19,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "v",
+            "localName": "span",
             "title": "Neil deGrasse Tyson",
             "childNodes": [
               {

--- a/tests/integration/cycle-collector-talk.json
+++ b/tests/integration/cycle-collector-talk.json
@@ -19,7 +19,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "v",
+            "localName": "span",
             "title": "Kyle Huey",
             "childNodes": [
               {
@@ -48,7 +48,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "v",
+            "localName": "span",
             "title": "Chris Pearce",
             "childNodes": [
               {
@@ -61,7 +61,7 @@
           },
           {
             "tagName": "span",
-            "localName": "v",
+            "localName": "span",
             "title": "Kyle Huey",
             "childNodes": [
               {
@@ -102,7 +102,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "v",
+            "localName": "span",
             "title": "Kyle Huey",
             "childNodes": [
               {
@@ -143,7 +143,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "v",
+            "localName": "span",
             "title": "Kyle Huey",
             "childNodes": [
               {
@@ -172,7 +172,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "v",
+            "localName": "span",
             "title": "Kyle Huey",
             "childNodes": [
               {
@@ -201,7 +201,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "v",
+            "localName": "span",
             "title": "Kyle Huey",
             "childNodes": [
               {
@@ -242,7 +242,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "v",
+            "localName": "span",
             "title": "Kyle Huey",
             "childNodes": [
               {
@@ -271,7 +271,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "v",
+            "localName": "span",
             "title": "Kyle Huey",
             "childNodes": [
               {
@@ -312,7 +312,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "v",
+            "localName": "span",
             "title": "Kyle Huey",
             "childNodes": [
               {
@@ -341,7 +341,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "v",
+            "localName": "span",
             "title": "Kyle Huey",
             "childNodes": [
               {
@@ -382,7 +382,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "v",
+            "localName": "span",
             "title": "Kyle Huey",
             "childNodes": [
               {
@@ -411,7 +411,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "v",
+            "localName": "span",
             "title": "Kyle Huey",
             "childNodes": [
               {
@@ -440,7 +440,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "v",
+            "localName": "span",
             "title": "Kyle Huey",
             "childNodes": [
               {
@@ -469,7 +469,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "v",
+            "localName": "span",
             "title": "Kyle Huey",
             "childNodes": [
               {
@@ -510,7 +510,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "v",
+            "localName": "span",
             "title": "Kyle Huey",
             "childNodes": [
               {

--- a/tests/integration/spec-example.json
+++ b/tests/integration/spec-example.json
@@ -19,7 +19,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "v",
+            "localName": "span",
             "title": "Roger Bingham",
             "childNodes": [
               {
@@ -48,7 +48,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "v",
+            "localName": "span",
             "title": "Roger Bingham",
             "childNodes": [
               {
@@ -77,7 +77,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "v",
+            "localName": "span",
             "title": "Roger Bingham",
             "childNodes": [
               {
@@ -106,7 +106,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "v",
+            "localName": "span",
             "title": "Roger Bingham",
             "childNodes": [
               {
@@ -135,7 +135,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "v",
+            "localName": "span",
             "title": "Roger Bingham",
             "childNodes": [
               {
@@ -164,7 +164,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "v",
+            "localName": "span",
             "title": "Roger Bingham",
             "childNodes": [
               {
@@ -193,7 +193,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "v",
+            "localName": "span",
             "title": "Roger Bingham",
             "childNodes": [
               {
@@ -222,7 +222,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "v",
+            "localName": "span",
             "title": "Roger Bingham",
             "childNodes": [
               {
@@ -251,7 +251,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "v",
+            "localName": "span",
             "title": "Roger Bingham",
             "childNodes": [
               {
@@ -280,7 +280,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "v",
+            "localName": "span",
             "title": "Neil deGrasse Tyson",
             "childNodes": [
               {
@@ -309,7 +309,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "v",
+            "localName": "span",
             "title": "Roger Bingham",
             "childNodes": [
               {
@@ -338,13 +338,13 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "v",
+            "localName": "span",
             "title": "Neil deGrasse Tyson",
             "childNodes": [
               {
-                "tagName" : "i",
-                "localName" : "i",
-                "childNodes" : [
+                "tagName": "i",
+                "localName": "i",
+                "childNodes": [
                   {
                     "textContent": "Laughs"
                   }
@@ -373,7 +373,7 @@
         "childNodes": [
           {
             "tagName": "span",
-            "localName": "v",
+            "localName": "span",
             "title": "Roger Bingham",
             "childNodes": [
               {

--- a/vtt.js
+++ b/vtt.js
@@ -236,7 +236,7 @@ function parseContent(window, input) {
     if (!tagName)
       return null;
     var element = window.document.createElement(tagName);
-    element.localName = type;
+    element.localName = tagName;
     var name = TAG_ANNOTATION[type];
     if (name && annotation)
       element[name] = annotation.trim();
@@ -245,12 +245,16 @@ function parseContent(window, input) {
 
   var current = fragment;
   var t;
+  var tagStack = [];
   while ((t = nextToken()) !== null) {
     if (t[0] === '<') {
       if (t[1] === "/") {
         // If the closing tag matches, move back up to the parent node.
-        if (current.localName === t.substr(2).replace(">", ""))
+        if (tagStack.length &&
+            tagStack[tagStack.length - 1] === t.substr(2).replace(">", "")) {
+          tagStack.pop();
           current = current.parentNode;
+        }
         // Otherwise just ignore the end tag.
         continue;
       }
@@ -281,6 +285,7 @@ function parseContent(window, input) {
         node.className = m[2].substr(1).replace('.', ' ');
       // Append the node to the current node, and enter the scope of the new
       // node.
+      tagStack.push(m[1]);
       current.appendChild(node);
       current = node;
       continue;


### PR DESCRIPTION
- The tag name for cuetext class tags should be span according to the
  WebVTT DOM construction rules.
- The local names of the generated HTML elements should be set to the name of the HTML tag rather then the cuetext tag.

Relevant spec rules [here](http://dev.w3.org/html5/webvtt/#webvtt-cue-text-dom-construction-rules).
