### PR TITLE
topOffset should be subtracted from viewportAnchorY

### DIFF
--- a/tests/processing-model/basic.json
+++ b/tests/processing-model/basic.json
@@ -14,7 +14,7 @@
       "minHeight": "0",
       "maxHeight": "0.1599px",
       "left": "10%",
-      "top": "9.8401%",
+      "top": "89.8401%",
       "display": "inline-flex",
       "flexFlow": "column",
       "justifyContent": "flex-end"

--- a/vtt.js
+++ b/vtt.js
@@ -680,7 +680,7 @@
 
     var left = region.viewportAnchorX - 
                region.regionAnchorX * region.width / 100,
-        top = region.viewportAnchorX -
+        top = region.viewportAnchorY -
               region.regionAnchorY * region.lines * LINE_HEIGHT / 100;
 
     this.applyStyles({


### PR DESCRIPTION
I was reading through the specs and I just happened to spot the minor error. Found under processing model -> step 10, substep 1.
