### PR TITLE
Don't run processing model tests by default in util.js

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -31,8 +31,10 @@ function filterJson(key, value) {
 // Parse the data (i.e., file is already read into `data`), potentially
 // splitting parsing into two chunks at `chunkAt`. Leave `chunkAt`
 // undefined to parse file whole. The `decoder` is how we'll decode the
-// data (null means use default TextDecoder).
-function _parse(data, decoder, chunkAt) {
+// data (null means use default TextDecoder). If `runProcModel` is set
+// to true then it will run the processing model over each indivual cue
+// as well and attach the output to the cue.
+function _parse(data, decoder, chunkAt, runProcModel) {
   var result = {
     regions: [],
     cues: []
@@ -43,7 +45,8 @@ function _parse(data, decoder, chunkAt) {
   p.oncue = function(cue) {
     // Also parse the cue's content and run the cue through the processing
     // model.
-    cue.domTree = WebVTTParser.processCues(FakeWindow, [cue])[0];
+    if (runProcModel)
+      cue.domTree = WebVTTParser.processCues(FakeWindow, [cue])[0];
     result.cues.push(cue);
   };
   p.onregion = function(region) {
@@ -71,13 +74,13 @@ function parse(filename, usePathUnchanged) {
     filename = fixTestPath(filename);
   }
 
-  return _parse(fs.readFileSync(filename).toUint8Array());
+  return _parse(fs.readFileSync(filename).toUint8Array(), null, null, true);
 }
 
 function getVttData(data, decoder, chunkAt) {
   var vttData;
   try {
-    vttData = _parse(data, decoder, chunkAt);
+    vttData = _parse(data, decoder, chunkAt, true);
   } catch(e) {
     return null;
   }
@@ -94,7 +97,7 @@ function getVttData(data, decoder, chunkAt) {
 function _runProcessingModel(vttFilename, usePathUnchanged) {
   vttFilename = usePathUnchanged ? vttFilename : fixTestPath(vttFilename);
   var vttData = _parse(fs.readFileSync(vttFilename).toUint8Array());
-  return WebVTTParser.processCues(FakeWindow, vttData.cues, vttData.regions);
+  return WebVTTParser.processCues(FakeWindow, vttData.cues, vttData.regions, false);
 }
 
 function runProcessingModel(vttFilename) {


### PR DESCRIPTION
This was causing us to run the processing model many times when
running processing model tests instead of just running it once
like we need too.
