### PR TITLE
Add support to test the processing model in PhantomJS.

### DIFF
--- a/lib/phantom-testrunner.js
+++ b/lib/phantom-testrunner.js
@@ -4,7 +4,7 @@
 // data (null means use default TextDecoder). If `runProcModel` is set
 // to true then it will run the processing model over each indivual cue
 // as well and attach the output to the cue.
-function parse(data, decoder, chunkAt, runProcModel) {
+function parse(data, decoder, chunkAt) {
   var result = {
     regions: [],
     cues: []
@@ -13,11 +13,6 @@ function parse(data, decoder, chunkAt, runProcModel) {
 
   var p = new WebVTTParser(window, decoder);
   p.oncue = function(cue) {
-    // Also parse the cue's content and run the cue through the processing
-    // model.
-    if (runProcModel) {
-      cue.domTree = WebVTTParser.processCues(window, [cue])[0];
-    }
     result.cues.push(cue);
   };
   p.onregion = function(region) {
@@ -35,10 +30,14 @@ function parse(data, decoder, chunkAt, runProcModel) {
   return result;
 }
 
+// Make sure the passed object is in JSON form.
+function jsonify(object) {
+  return JSON.parse(JSON.stringify(object));
+}
+
 // Parse the data and return it as JSON.
-function parseToJson(data, decoder, chunkAt, runProcModel) {
-  return JSON.parse(JSON.stringify(parse(data, decoder, chunkAt,
-                                         runProcModel)));
+function parseToJson(data, decoder, chunkAt) {
+  return jsonify(parse(data, decoder, chunkAt));
 }
 
 // Get the file data from the server for the specified VTT and JSON files.
@@ -77,6 +76,71 @@ function fail(message) {
   assert.ok(false, message);
 }
 
+
+// The properties on DOM objects that we care about testing.
+var testProperties = ( "localName tagName className textContent" +
+                       " lang target data title" ).split(" ");
+
+// Grab only the properties that we care about off an HTMLElement.
+function filterElement(element) {
+  var result = {};
+
+  testProperties.forEach(function(prop) {
+    if (_.has(element, prop)) {
+      result[prop] = element[prop];
+    }
+  });
+
+  if (_.has(element, "style")) {
+    result.style = {};
+    for (var i = 0, l = element.style.length; i < l; i++) {
+      var prop = element.style[i];
+      result.style[prop] = element.style[prop];
+    }
+  }
+
+  if (_.has(element, "childNodes")) {
+    result.childNodes = [];
+    for (var x = 0, y = element.childNodes.length; x < y; x++) {
+      result.childNodes.push(filterElement(element.childNodes[x]));
+    }
+  }
+
+  return result;
+}
+
+// Run the processing model over parsed VTT data and compare it to a JSON
+// representation of the correct output.
+chai.assert.procModelEquals = function(vttFilename, jsonFilename, onFinish) {
+  if (jsonFilename instanceof Function) {
+    onFinish = jsonFilename;
+    jsonFilename = null;
+  }
+
+  requestFileData(vttFilename, jsonFilename, function(err, data) {
+    if (err) {
+      fail("Unable to get the test resources: " + err);
+      return onFinish();
+    }
+
+    var uint8Data = jsonToUint8Array(data.vtt.uint8),
+        vttData = parse(uint8Data);
+
+    divs = WebVTTParser.processCues(window, vttData.cues, vttData.regions);
+    divs = divs.map(function(div) {
+      return filterElement(div);
+    });
+
+    var json = jsonify(divs);
+    if (!deepEqual(json, data.json)) {
+      fail("running processing model over parsed output");
+    }
+
+    assert.ok(true, "Compare processing model results from " + vttFilename +
+                    " to " + jsonFilename);
+  });
+};
+
 chai.assert.jsonEqual = function(vttFilename, jsonFilename, onFinish) {
   if (jsonFilename instanceof Function) {
     onFinish = jsonFilename;
@@ -91,7 +155,7 @@ chai.assert.jsonEqual = function(vttFilename, jsonFilename, onFinish) {
 
     // First check that things work when parsing the file as a whole.
     var uint8Data = jsonToUint8Array(data.vtt.uint8),
-        json = parseToJson(uint8Data, null, null, false);
+        json = parseToJson(uint8Data);
 
     if (!deepEqual(json, data.json)) {
       fail("parsing file as binary utf8 without streaming");
@@ -100,7 +164,7 @@ chai.assert.jsonEqual = function(vttFilename, jsonFilename, onFinish) {
     var size = data.vtt.uint8.length;
     // Now check again using streaming with different chunk sizes
     while (--size >= 3) {
-      json = parseToJson(uint8Data, null, size, false);
+      json = parseToJson(uint8Data, null, size);
       if (!deepEqual(json, data.json)) {
         var chunk1 = (new Buffer(data.subarray(0,size))).toString();
         var chunk2 = (new Buffer(data.subarray(size))).toString();
@@ -111,8 +175,7 @@ chai.assert.jsonEqual = function(vttFilename, jsonFilename, onFinish) {
     }
 
     // Finally, check it using a StringDecoder
-    json = parseToJson(data.vtt.string, WebVTTParser.StringDecoder(), null,
-                       false);
+    json = parseToJson(data.vtt.string, WebVTTParser.StringDecoder());
     if (!deepEqual(json, data.json)) {
       return fail("parsing file as string without streaming");
     }


### PR DESCRIPTION
Before I land this I'd like to convert over all the previous tests to use PhantomJS and split out the processing model JSON files from the parsing JSON files.

@humphd do you have any preferences for the directory structure for the split up tests. I have a couple of ideas:
1. We keep the current directory structure and just have two JSON files for each test. One would be like [testName]-parsing.json and the other would be [testName]-procModel.json.
2. We have another level of directory underneath each testing directory. One would be `parsing-json` and the other would be `processing-model-json`. I like this one as we may not want to run the processing model over every VTT file we have.
