### PR TITLE
IE8 Support

### DIFF
--- a/vtt.js
+++ b/vtt.js
@@ -3,19 +3,17 @@
 
 (function(global) {
 
-  if (!Object.create) {
-    Object.create = (function(){
-      function F(){}
+  _objCreate = (function(){
+    function F(){}
 
-      return function(o){
-        if (arguments.length != 1) {
-          throw new Error('Object.create implementation only accepts one parameter.');
-        }
-        F.prototype = o;
-        return new F();
-      };
-    })();
-  }
+    return function(o){
+      if (arguments.length != 1) {
+        throw new Error('Object.create implementation only accepts one parameter.');
+      }
+      F.prototype = o;
+      return new F();
+    };
+  })();
 
   // Try to parse input as a time stamp.
   function parseTimeStamp(input) {
@@ -44,7 +42,7 @@
   // A settings object holds key/value pairs and will ignore anything but the first
   // assignment to a specific key.
   function Settings() {
-    this.values = Object.create(null);
+    this.values = _objCreate(null);
   }
 
   Settings.prototype = {
@@ -704,7 +702,7 @@
       "textAlign": cue.align === "middle" ? "center" : cue.align
     });
   }
-  BasicBoundingBox.prototype = Object.create(BoundingBox.prototype);
+  BasicBoundingBox.prototype = _objCreate(BoundingBox.prototype);
   BasicBoundingBox.prototype.constructor = BasicBoundingBox;
 
   var CUE_FONT_SIZE = 2.5;
@@ -727,7 +725,7 @@
       whiteSpace: "pre-line"
     });
   }
-  CueBoundingBox.prototype = Object.create(BasicBoundingBox.prototype);
+  CueBoundingBox.prototype = _objCreate(BasicBoundingBox.prototype);
   CueBoundingBox.prototype.constuctor = CueBoundingBox;
 
   function RegionBoundingBox(window, region) {
@@ -783,7 +781,7 @@
       return true;
     };
   }
-  RegionBoundingBox.prototype = Object.create(BoundingBox.prototype);
+  RegionBoundingBox.prototype = _objCreate(BoundingBox.prototype);
   RegionBoundingBox.prototype.constructor = RegionBoundingBox;
 
   function WebVTTParser(window, decoder) {


### PR DESCRIPTION
Fixes #182, #183.

The commit list is a pretty good record of each change. I couldn't get tests to pass in a clean clone so wasn't able to verify that the tests still pass.

I added an Object.create shim despite my previous comment, because there was no easy way around it. It might actually be better to create an internal object.create function instead of updating the global Object to make sure it doesn't conflict with other implementations.

The textComment to innerHTML change I believe should work since it's already text nodes, but that should be tested.

With these changes I can run vtt.js in IE8 without any script errors, but it doesn't complete the parsing because it [tries to make a new window.VTTCue](https://github.com/mozilla/vtt.js/blob/master/vtt.js#L964), which doesn't exist on window, and then the [try/catch](https://github.com/mozilla/vtt.js/blob/master/vtt.js#L1006) swallows the error. Not exactly sure what the next steps are to fix that, so I'll open another issue for it.
