### PR TITLE
Properly handle VTTCue and VTTRegion to and from JSON,

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -19,7 +19,9 @@ module.exports = function( grunt ) {
       files: [
         "vtt.js",
         "lib/vttcue.js",
+        "lib/vttcue-extended.js",
         "lib/vttregion.js",
+        "lib/vttregion-extended.js",
         "lib/node-vtt.js"
       ]
     },

--- a/lib/node-vtt.js
+++ b/lib/node-vtt.js
@@ -1,15 +1,7 @@
 var Phantom = require("node-phantom"),
+    VTTCue = require("./vttcue-extended").VTTCue,
+    VTTRegion = require("./vttregion-extended").VTTRegion,
     fs = require("fs");
-
-function filterCue(cue) {
-  var filteredCue = {};
-  for (var key in cue) {
-    if (key !== "getCueAsHTML" && key !== "_reset") {
-      filteredCue[key] = cue[key];
-    }
-  }
-  return filteredCue;
-}
 
 // NodeVTT is a NodeJS wrapper for vtt.js that runs on an instance of PhantomJS.
 // Aggregates the parsed cues and regions in NodeVTT.cues and NodeVTT.regions.
@@ -61,8 +53,8 @@ NodeVTT.prototype.init = function(uri, onInit) {
         };
         // Aggregate the parsed cues and regions.
         self.page.onCallback = function(data) {
-          data.cue && self.cues.push(filterCue(data.cue));
-          data.region && self.regions.push(data.region);
+          data.cue && self.cues.push(VTTCue.create(data.cue));
+          data.region && self.regions.push(VTTRegion.create(data.region));
         };
         self.phantom = ph;
         onInit();
@@ -172,6 +164,12 @@ NodeVTT.prototype.processParsedData = function(data, onProcessed) {
   var cues = (data && ("cues" in data)) ? data.cues : this.cues,
       regions = (data && ("regions" in data)) ? data.regions : this.regions;
   this.page.evaluate(function(cues, regions) {
+    cues = cues.map(function(cue) {
+      return VTTCue.create(cue);
+    });
+    regions = regions.map(function(region) {
+      return VTTRegion.create(region);
+    });
     return WebVTTParser.processCues(window, cues, regions).map(function(div) {
       return filterElement(div);
     });

--- a/lib/test-runner.js
+++ b/lib/test-runner.js
@@ -21,6 +21,11 @@ function fail(message, error) {
 
 // Evaluate data from test and determine if it's a pass or fail.
 function testDone(error, vtt, json, message, testType, onDone) {
+  try {
+    vtt = JSON.parse(JSON.stringify(vtt));
+  } catch(e) {
+    fail(message, "Unable to JSONify VTT data.");
+  }
   if (error) {
     fail(message, "Failed test while " + testType + ".");
   } else if (!deepEqual(vtt, json)) {

--- a/lib/vttcue-extended.js
+++ b/lib/vttcue-extended.js
@@ -1,0 +1,44 @@
+// If we're in Node.js then require VTTCue so we can extend it, otherwise assume
+// VTTCue is on the global.
+if (typeof module !== "undefined" && module.exports) {
+  this.VTTCue = this.VTTCue || require("./vttcue").VTTCue;
+}
+
+// Extend VTTCue with methods to convert to JSON, from JSON, and construct a
+// VTTCue from an options object. The primary purpose of this is for use in the
+// vtt.js test suite (for testing only properties that we care about). It's also
+// useful if you need to work with VTTCues in JSON format.
+(function(root) {
+
+  root.VTTCue.prototype.toJSON = function() {
+    var cue = {},
+        self = this;
+    // Filter out getCueAsHTML as it's a function and _reset and displayState as
+    // they're only used when running the processing model algorithm.
+    Object.keys(this).forEach(function(key) {
+      if (key !== "getCueAsHTML" && key !== "_reset" && key !== "displayState") {
+        cue[key] = self[key];
+      }
+    });
+    return cue;
+  };
+
+  root.VTTCue.create = function(options) {
+    if (!options.hasOwnProperty("startTime") || !options.hasOwnProperty("endTime") ||
+        !options.hasOwnProperty("text")) {
+      throw new Error("You must at least have start time, end time, and text.");
+    }
+    var cue = new root.VTTCue(options.startTime, options.endTime, options.text);
+    for (var key in options) {
+      if (cue.hasOwnProperty(key)) {
+        cue[key] = options[key];
+      }
+    }
+    return cue;
+  };
+
+  root.VTTCue.fromJSON = function(json) {
+    return this.create(JSON.parse(json));
+  };
+
+}(this));

--- a/lib/vttregion-extended.js
+++ b/lib/vttregion-extended.js
@@ -1,0 +1,27 @@
+// If we're in Node.js then require VTTRegion so we can extend it, otherwise assume
+// VTTRegion is on the global.
+if (typeof module !== "undefined" && module.exports) {
+  this.VTTRegion = require("./vttregion").VTTRegion;
+}
+
+// Extend VTTRegion with methods to convert to JSON, from JSON, and construct a
+// VTTRegion from an options object. The primary purpose of this is for use in the
+// vtt.js test suite. It's also useful if you need to work with VTTRegions in
+// JSON format.
+(function(root) {
+
+  root.VTTRegion.create = function(options) {
+    var region = new root.VTTRegion();
+    for (var key in options) {
+      if (region.hasOwnProperty(key)) {
+        region[key] = options[key];
+      }
+    }
+    return region;
+  };
+
+  root.VTTRegion.create = function(json) {
+    return this.create(JSON.parse(json));
+  };
+
+}(this));

--- a/utils/basic.html
+++ b/utils/basic.html
@@ -2,6 +2,8 @@
 <html>
   <head>
     <script src="../dist/vtt.js"></script>
+    <script src="../lib/vttcue-extended.js"></script>
+    <script src="../lib/vttregion-extended.js"></script>
     <script type="text/javascript">
       function setup() {
         window.p = new WebVTTParser(window);


### PR DESCRIPTION
- VTTCues and VTTRegions should be able to be constructed from JSON.
- NodeVTT should actually return VTTCue and VTTRegion objects, not just JSON
  versions of them. VTTCue should be JSONified without _reset, getCueAsHTML,
  and displayState properties.

Depends on #187.

I'm think it would be better to have something like vttcue-json.js and vttregion-json.js that extends the two classes for `toJSON` and `fromJSON`. If the user wants that functionality they can include that file instead of the base `vttcue.js`. Maybe requirejs for the separate files?

It'd also be good to be able to include these extensions in either Node or browser and maybe even build a `vtt.js` that has the one the user wants. I'm not sure the best way to go about this.
