### PR TITLE
Turn processing model tests that were accidentally turned off back on.

### DIFF
--- a/lib/test-runner.js
+++ b/lib/test-runner.js
@@ -336,6 +336,27 @@ TestRunner.prototype.jsonEqualProcModel = function(vttFile, jsonFile, message, o
   });
 };
 
+// Compare JSON to live parsed data that has been run through the processing model
+// and parsed data without streaming.
+TestRunner.prototype.jsonEqualAllNoStream =  function(vttFile, jsonFile, message, onTestFinish) {
+  this.assertReady();
+
+  var self = this;
+  if (typeof message === "function") {
+    onTestFinish = message;
+    message = null;
+  }
+  async.series({
+    first: function(onContinue) {
+      self.jsonEqual(vttFile, jsonFile, message, onContinue);
+    },
+    second: function(onContinue) {
+      jsonFile = vttFile.replace(/\.vtt$/, "-proc.json");
+      self.jsonEqualProcModel(vttFile, jsonFile, message, onContinue);
+    }
+  }, onTestFinish);
+};
+
 // Compare JSON to live parsed output for streaming, parsing whole, and processing
 // VTT data.
 TestRunner.prototype.jsonEqualAll =  function(vttFile, jsonFile, message, onTestFinish) {

--- a/tests/cuetext/format/test.js
+++ b/tests/cuetext/format/test.js
@@ -20,7 +20,7 @@ describe("cuetext/format tests", function(){
   });
 
   it("long-line.vtt", function(onDone){
-    test.jsonEqual("cuetext/format/long-line.vtt", "cuetext/format/long-line.json", onDone);
+    test.jsonEqualAllNoStream("cuetext/format/long-line.vtt", "cuetext/format/long-line.json", onDone);
   });
 
   it("no-line-break.vtt", function(onDone){

--- a/tests/file-layout/test.js
+++ b/tests/file-layout/test.js
@@ -27,6 +27,7 @@ describe("file-layout tests", function(){
     test.jsonEqualAll("file-layout/bom-tab-webvtt.vtt", "file-layout/no-output.json", onDone);
   });  
 
+  // Turn back on: https://github.com/mozilla/vtt.js/issues/262
   it("cue-spacing.vtt", function(onDone){
     test.jsonEqual("file-layout/cue-spacing.vtt", "file-layout/cue-spacing.json", onDone);
   });
@@ -39,6 +40,7 @@ describe("file-layout tests", function(){
     test.jsonEqualAll("file-layout/header-no-new-line.vtt", "file-layout/no-output.json", onDone);
   });
 
+  // Turn back on: https://github.com/mozilla/vtt.js/issues/262
   it("many-comments.vtt", function(onDone){
     test.jsonEqual("file-layout/many-comments.vtt", "file-layout/many-comments.json", onDone);
   });  

--- a/tests/integration/test.js
+++ b/tests/integration/test.js
@@ -12,45 +12,52 @@ describe("integration tests", function(){
   });
 
   it("arrows.vtt", function(onDone){
-    test.jsonEqual("integration/arrows.vtt", "integration/arrows.json", onDone);
+    test.jsonEqualAllNoStream("integration/arrows.vtt", "integration/arrows.json", onDone);
   });
 
   it("cue-content-class.vtt", function(onDone){
-    test.jsonEqual("integration/cue-content-class.vtt", "integration/cue-content-class.json", onDone);
+    test.jsonEqualAllNoStream("integration/cue-content-class.vtt", "integration/cue-content-class.json", onDone);
   });
 
   it("cue-content.vtt", function(onDone){
-    test.jsonEqual("integration/cue-content.vtt", "integration/cue-content.json", onDone);
+    test.jsonEqualAllNoStream("integration/cue-content.vtt", "integration/cue-content.json", onDone);
   });
 
   it("cue-identifier.vtt", function(onDone){
-    test.jsonEqual("integration/cue-identifier.vtt", "integration/cue-identifier.json", onDone);
+    test.jsonEqualAllNoStream("integration/cue-identifier.vtt", "integration/cue-identifier.json", onDone);
   });
 
+  // Turn back on: https://github.com/mozilla/vtt.js/issues/262
   it("cycle-collector-talk.vtt", function(onDone){
     test.jsonEqual("integration/cycle-collector-talk.vtt", "integration/cycle-collector-talk.json", onDone);
   });
 
+  // Turn back on: https://github.com/mozilla/vtt.js/issues/262
   it("id.vtt", function(onDone){
     test.jsonEqual("integration/id.vtt", "integration/id.json", onDone);
   });
 
+  // Turn back on: https://github.com/mozilla/vtt.js/issues/262
   it("not-only-nested-cues.vtt", function(onDone){
     test.jsonEqual("integration/not-only-nested-cues.vtt", "integration/not-only-nested-cues.json", onDone);
   });
 
+  // Turn back on: https://github.com/mozilla/vtt.js/issues/262
   it("one-line-comment.vtt", function(onDone){
     test.jsonEqual("integration/one-line-comment.vtt", "integration/one-line-comment.json", onDone);
   });
 
+  // Turn back on: https://github.com/mozilla/vtt.js/issues/262
   it("only-nested-cues.vtt", function(onDone){
     test.jsonEqual("integration/only-nested-cues.vtt", "integration/only-nested-cues.json", onDone);
   });
 
+  // Turn back on: https://github.com/mozilla/vtt.js/issues/262
   it("regions.vtt", function(onDone){
     test.jsonEqual("integration/regions.vtt", "integration/regions.json", onDone);
   });
 
+  // Turn back on: https://github.com/mozilla/vtt.js/issues/262
   it("spec-example.vtt", function(onDone){
     test.jsonEqual("integration/spec-example.vtt", "integration/spec-example.json", onDone);
   });


### PR DESCRIPTION
I've added a new test-runner method that tests both parsing, without
streaming, and processing whole VTT files.

Fixes #258.
