### PR TITLE
Calculate the line height exactly.

### DIFF
--- a/tests/integration/cycle-collector-talk-proc.json
+++ b/tests/integration/cycle-collector-talk-proc.json
@@ -371,7 +371,7 @@
     "lang": "",
     "localName": "div",
     "style": {
-      "bottom": "56px",
+      "bottom": "49px",
       "direction": "ltr",
       "font": "normal normal normal 7.3px/normal sans-serif",
       "height": "14px",
@@ -379,7 +379,7 @@
       "position": "absolute",
       "right": "0px",
       "text-align": "center",
-      "top": "76px",
+      "top": "83px",
       "white-space": "pre-line",
       "width": "292px"
     },
@@ -459,7 +459,7 @@
     "lang": "",
     "localName": "div",
     "style": {
-      "bottom": "49px",
+      "bottom": "63px",
       "direction": "ltr",
       "font": "normal normal normal 7.3px/normal sans-serif",
       "height": "7px",
@@ -467,7 +467,7 @@
       "position": "absolute",
       "right": "0px",
       "text-align": "center",
-      "top": "90px",
+      "top": "76px",
       "white-space": "pre-line",
       "width": "292px"
     },
@@ -821,7 +821,7 @@
     "lang": "",
     "localName": "div",
     "style": {
-      "bottom": "112px",
+      "bottom": "105px",
       "direction": "ltr",
       "font": "normal normal normal 7.3px/normal sans-serif",
       "height": "14px",
@@ -829,7 +829,7 @@
       "position": "absolute",
       "right": "0px",
       "text-align": "center",
-      "top": "20px",
+      "top": "27px",
       "white-space": "pre-line",
       "width": "292px"
     },
@@ -883,7 +883,7 @@
     "lang": "",
     "localName": "div",
     "style": {
-      "bottom": "105px",
+      "bottom": "119px",
       "direction": "ltr",
       "font": "normal normal normal 7.3px/normal sans-serif",
       "height": "7px",
@@ -891,7 +891,7 @@
       "position": "absolute",
       "right": "0px",
       "text-align": "center",
-      "top": "34px",
+      "top": "20px",
       "white-space": "pre-line",
       "width": "292px"
     },

--- a/vtt.js
+++ b/vtt.js
@@ -764,10 +764,17 @@
     // was passed in and we need to copy the results of 'getBoundingClientRect'
     // as the object returned is readonly. All co-ordinate values are in reference
     // to the viewport origin (top left).
-    var lines;
+    var lh;
     if (obj.div) {
-      lines = obj.div.textContent.split("\n").length;
+      var rects = (rects = obj.div.childNodes) && (rects = rects[0]) &&
+                  rects.getClientRects && rects.getClientRects();
       obj = obj.div.getBoundingClientRect();
+      // In certain cases the outter div will be slightly larger then the sum of
+      // the inner div's lines. This could be due to bold text, etc, on some platforms.
+      // In this case we should get the average line height and use that. This will
+      // result in the desired behaviour.
+      lh = rects ? Math.max((rects[0] && rects[0].height) || 0, obj.height / rects.length)
+                 : 0;
     }
     this.left = obj.left;
     this.right = obj.right;
@@ -775,7 +782,7 @@
     this.height = obj.height;
     this.bottom = obj.bottom;
     this.width = obj.width;
-    this.lineHeight = obj.lineHeight || (lines && (this.height / lines));
+    this.lineHeight = lh !== undefined ? lh : obj.lineHeight;
   }
 
   // Move the box along a particular axis. If no amount to move is passed, via


### PR DESCRIPTION
We can now use 'getClientRects' to get the exact line height
of any of the lines in the cue box.

Fixes #261.
