### PR TITLE
Don't throw errors if they are ParsingErrors.

### DIFF
--- a/vtt.js
+++ b/vtt.js
@@ -1373,8 +1373,6 @@
         // Enter BADWEBVTT state if header was not parsed correctly otherwise
         // another exception occurred so enter BADCUE state.
         self.state = self.state === "INITIAL" ? "BADWEBVTT" : "BADCUE";
-
-        throw e;
       }
       return this;
     },


### PR DESCRIPTION
Instead report them to the consumer of vtt.js.
This was a regression caused by commit:
e55e9c2e8b5e972b324ae72b867c711fa59a5ae5
