### PR TITLE
Use 'encodeURIComponent' instead of 'escape' as it is deprecated.

### DIFF
--- a/lib/vtt.js
+++ b/lib/vtt.js
@@ -1068,7 +1068,7 @@
         if (typeof data !== "string") {
           throw new Error("Error - expected string data.");
         }
-        return decodeURIComponent(escape(data));
+        return decodeURIComponent(encodeURIComponent(data));
       }
     };
   };


### PR DESCRIPTION
Partial fix for #97. I still have to enable the tests which will take some changes to `TestRunner` and `NodeVTT`. I'll move `NodeVTT` over to its new repo before we start that though.
