### PR TITLE
Re-enable 'unused' config option for jshint.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,8 +13,7 @@ module.exports = function( grunt ) {
         curly: true,
         eqeqeq: true,
         newcap: true,
-        // Add this back once process algo is fixed // unused: true,
-        // See https://github.com/mozilla/vtt.js/issues/203
+        unused: true,
         trailing: true,
         browser: true,
         node: true

--- a/lib/vtt.js
+++ b/lib/vtt.js
@@ -800,8 +800,6 @@
   // compute things with such as if it overlaps or intersects with another Element.
   // Can initialize it with either a StyleBox or another BoxPosition.
   function BoxPosition(obj) {
-    var self = this;
-
     // Either a BoxPosition was passed in and we need to copy it, or a StyleBox
     // was passed in and we need to copy the results of 'getBoundingClientRect'
     // as the object returned is readonly. All co-ordinate values are in reference


### PR DESCRIPTION
This was supposed to have been done a long time ago, but got
forgotten about. Most of the issues have been cleared up since
then. Just one small issue remained which I've fixed in the
BoxPosition class.
