### PR TITLE
Optimize the processing algorithm for large line values.

### DIFF
--- a/lib/vtt.js
+++ b/lib/vtt.js
@@ -832,17 +832,17 @@
     "-y": [ "top", "bottom" ],
   };
 
-  // Move the box along a particular axis. If no amount to move is passed, via
-  // the val parameter, then the default amount is the line height of the box.
-  // Pass an optional container box to clamp the box to the maximum position
-  // that still has some overlap with the container box.
-  BoxPosition.prototype.move = function(axis, val, container) {
-    val = val !== undefined ? val : this.lineHeight;
+  // Move the box along a particular axis. Optionally pass in an amount to move
+  // or a container box to clamp the max amount moved to through the options
+  // parameter.
+  BoxPosition.prototype.move = function(axis, options) {
+    options = options || {};
 
     // Negate the amount to move the box since we're moving along the
     // neagtive axis.
+    var toMove = options.toMove !== undefined ? options.toMove : this.lineHeight;
     if (axis.indexOf("-") !== -1) {
-      val *= -1;
+      toMove *= -1;
     }
 
     var axes = axesMaps[axis];
@@ -851,11 +851,12 @@
     }
 
     for (var i = 0; i < axes.length; i++) {
-      this[axes[i]] += val;
+      this[axes[i]] += toMove;
     }
 
     // If we don't have a container, are already within the container, or have
     // a line height of 0 then there is no need to clamp.
+    var container = options.container;
     if (!container || this.overlaps(container) || this.lineHeight === 0) {
       return;
     }
@@ -873,9 +874,9 @@
     // fewest amount of 'step' intervals and intersect the container box.
     var step = this.lineHeight,
         stepOffset = diff / step,
-        toMove = stepOffset === 0 ? stepOffset : Math.floor(stepOffset - 1);
+        stepsToMove = stepOffset === 0 ? stepOffset : Math.floor(stepOffset - 1);
     // Move the box that amount of steps in the opposite direction.
-    this.move(axis, toMove * step * -1);
+    this.move(axis, { toMove: stepsToMove * step * -1 });
   };
 
   // Check if this box overlaps another box, b2.
@@ -1036,7 +1037,7 @@
 
       // Move the box to the specified position. This may not be its best
       // position.
-      boxPosition.move(initialAxis, initialPosition, containerBox);
+      boxPosition.move(initialAxis, { toMove: initialPosition, container: containerBox });
 
     } else {
       // If we have a percentage line value for the cue.


### PR DESCRIPTION
In the case where we have a large line integer value we should optimize
the algorithm so that we skip through all the individual 'step moves'.
To do this I've optimized it to calculate the amount it should move to
be just outside the container while preserving the interval of step
that it should be on.

Fixes #266.
