### PR TITLE
Fix issues in line optimization.

### DIFF
--- a/lib/vtt.js
+++ b/lib/vtt.js
@@ -119,7 +119,6 @@
     // Accept a setting if its a valid (signed) integer.
     integer: function(k, v) {
       if (/^-?\d+$/.test(v)) { // integer
-        // Only take values in the range of -1000 ~ 1000
         this.set(k, parseInt(v, 10));
       }
     },
@@ -825,40 +824,28 @@
     this.lineHeight = lh !== undefined ? lh : obj.lineHeight;
   }
 
-  var axesMaps = {
-    "x": { edges: [ "left", "right" ], ref: "width" },
-    "y": { edges: [ "top", "bottom" ], ref: "height" }
-  };
-
   // Move the box along a particular axis. Optionally pass in an amount to move
-  // or a container box to clamp the max amount moved to through the options
-  // parameter.
-  BoxPosition.prototype.move = function(axis, options) {
-    options = options || {};
-
-    var axes = axesMaps[axis.replace(/(\+|-)/, "")];
-    if (!axes) {
-      throw new Error("You must pass in a valid axis (+x, -x, +y, -y).");
-    }
-
-    var toMove = options.toMove !== undefined ? options.toMove : this.lineHeight;
-    if (options.container) {
-      var step = this.lineHeight,
-          maxSteps = Math.floor((options.container[axes.ref] / step) + 1);
-      if (maxSteps < (toMove / step)) {
-        toMove = maxSteps * step;
-      }
-    }
-
-    // Negate the amount to move the box since we're moving along the
-    // neagtive axis.
-    if (axis.indexOf("-") !== -1) {
-      toMove *= -1;
-    }
-
-    var edges = axes.edges;
-    for (var i = 0; i < edges.length; i++) {
-      this[edges[i]] += toMove;
+  // the box. If no amount is passed then the default is the line height of the
+  // box.
+  BoxPosition.prototype.move = function(axis, toMove) {
+    toMove = toMove !== undefined ? toMove : this.lineHeight;
+    switch (axis) {
+    case "+x":
+      this.left += toMove;
+      this.right += toMove;
+      break;
+    case "-x":
+      this.left -= toMove;
+      this.right -= toMove;
+      break;
+    case "+y":
+      this.top += toMove;
+      this.bottom += toMove;
+      break;
+    case "-y":
+      this.top -= toMove;
+      this.bottom -= toMove;
+      break;
     }
   };
 
@@ -989,32 +976,47 @@
 
     // If we have a line number to align the cue to.
     if (cue.snapToLines) {
+      var size;
       switch (cue.vertical) {
       case "":
         axis = [ "+y", "-y" ];
+        size = "height";
         break;
       case "rl":
         axis = [ "+x", "-x" ];
+        size = "width";
         break;
       case "lr":
         axis = [ "-x", "+x" ];
+        size = "width";
         break;
+      }
+
+      var step = boxPosition.lineHeight,
+          position = step * Math.round(linePos),
+          maxPosition = containerBox[size] + step,
+          initialAxis = axis[0];
+
+      // If the specified intial position is greater then the max position then
+      // clamp the box to the amount of steps it would take for the box to
+      // reach the max position.
+      if (Math.abs(position) > maxPosition) {
+        position = position < 0 ? -1 : 1;
+        position *= Math.ceil(maxPosition / step) * step;
       }
 
       // If computed line position returns negative then line numbers are
       // relative to the bottom of the video instead of the top. Therefore, we
       // need to increase our initial position by the length or width of the
       // video, depending on the writing direction, and reverse our axis directions.
-      var initialPosition = boxPosition.lineHeight * Math.floor(linePos + 0.5),
-          initialAxis = axis[0];
       if (linePos < 0) {
-        initialPosition += cue.vertical === "" ? containerBox.height : containerBox.width;
+        position += cue.vertical === "" ? containerBox.height : containerBox.width;
         axis = axis.reverse();
       }
 
       // Move the box to the specified position. This may not be its best
       // position.
-      boxPosition.move(initialAxis, { toMove: initialPosition, container: containerBox });
+      boxPosition.move(initialAxis, position);
 
     } else {
       // If we have a percentage line value for the cue.


### PR DESCRIPTION
I've moved back to the old Box::Move function and instead have put
the line optimization steps before we move the box for the first
time. This makes more sense to me as:
1. We only perform this operatrion once, right before we move the
   box for the first time.
2. Putting it in the Box::Move function kind of ruins the abstraction
   of it since it has to know that the box is moving in 'steps' and not
   at an arbitrary amount to move.
3. It allows us to deal with negative line numbers easily. We optimize
   the amount to move before we add the extra lenght/width of the box
   to the position for negative line numbers. This was messing up the
   previous algorithm since it wasn't taking into account this extra
   amount added.

I've also fixed an incorrect comment left over from a previous
commit that was discovered by review happening in Gecko bug 974017.
