### PR TITLE
Use grunt mocha test to run mocha.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -70,6 +70,17 @@ module.exports = function( grunt ) {
         push: true,
         pushTo: "git@github.com:mozilla/vtt.js.git",
       }
+    },
+
+    mochaTest: {
+      test: {
+        options: {
+          reporter: "spec",
+          slow: "15000",
+          timeout: "120000"
+        },
+        src: [ "tests/**/*.js" ]
+      }
     }
 
   });
@@ -78,10 +89,11 @@ module.exports = function( grunt ) {
   grunt.loadNpmTasks( "grunt-contrib-uglify" );
   grunt.loadNpmTasks( "grunt-contrib-concat" );
   grunt.loadNpmTasks( "grunt-bump" );
+  grunt.loadNpmTasks( "grunt-mocha-test" );
 
   grunt.registerTask( "build", [ "uglify:dist", "concat:dist" ] );
   grunt.registerTask( "dev-build", [ "uglify:dev", "concat:dev" ])
-  grunt.registerTask( "default", [ "jshint", "dev-build" ]);
+  grunt.registerTask( "default", [ "jshint", "dev-build", "mochaTest" ]);
 
   grunt.registerTask( "stage-dist", "Stage dist files.", function() {
     exec( "git add dist/*", this.async() );

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "grunt-update-submodules": "0.3.0",
     "json-stable-stringify": "0.1.2",
     "node-vtt": "1.1.0",
-    "text-encoding": "0.0.0"
+    "text-encoding": "0.0.0",
+    "grunt-mocha-test": "0.10.2"
   },
   "main": "lib/index.js",
   "files": [
@@ -43,7 +44,7 @@
     "text track"
   ],
   "scripts": {
-    "test": "./node_modules/.bin/grunt && ./node_modules/.bin/mocha --recursive --reporter spec --timeout 120000 --slow 15000 tests"
+    "test": "./node_modules/.bin/grunt"
   },
   "license": {
     "type": "Apache-2.0",


### PR DESCRIPTION
This cleans up the package.json script a bit. Grunt-mocha-tests
automatically does things for us like catching assertions that
would normally be uncaught so that our test runner doesn't
explode at any point.
