### PR TITLE
Use the default travis grunt.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
 language: node_js
 node_js:
   - "0.10"
-before_script:
-  - npm install -g grunt-cli


### PR DESCRIPTION
We no longer need to install grunt manually; the travis-ci.org
environment now provides it for node projects.

Removing the install step also lets us run on the new
container-based infrastructure.