### PR TITLE
root.VTTCue should fall back to VVTCue if not set

### DIFF
--- a/lib/vttcue.js
+++ b/lib/vttcue.js
@@ -304,5 +304,5 @@
     return WebVTT.convertCueToDOMTree(window, this.text);
   };
 
-  root.VTTCue = VTTCue || root.VTTCue;
+  root.VTTCue = root.VTTCue || VTTCue;
 }(this));


### PR DESCRIPTION
VTTCue is never null so it always fell back, which doesn't work on some browsers.
