### PR TITLE
Remove localName (read only) assignment

### DIFF
--- a/lib/vtt.js
+++ b/lib/vtt.js
@@ -375,7 +375,6 @@
         return null;
       }
       var element = window.document.createElement(tagName);
-      element.localName = tagName;
       var name = TAG_ANNOTATION[type];
       if (name && annotation) {
         element[name] = annotation.trim();


### PR DESCRIPTION
localName on elements is defined as read only: https://developer.mozilla.org/en-US/docs/Web/API/Element/localName
Assigning to it silently fails or throws an exception if running in strict mode.