### PR TITLE
parseContent: support multiple classes definition

### DIFF
--- a/lib/vtt.js
+++ b/lib/vtt.js
@@ -425,7 +425,7 @@
         }
         // Set the class list (as a list of classes, separated by space).
         if (m[2]) {
-          node.className = m[2].substr(1).replace('.', ' ');
+          node.className = m[2].substr(1).replace(/\./g, ' ');
         }
         // Append the node to the current node, and enter the scope of the new
         // node.


### PR DESCRIPTION
When I have a subtitle with more than 2 classes (for example `<c.double.blue.bgwhite>Music sounds</c>`), the classes are not created properly. I have fixed it