### PR TITLE
Safari 12 workaround for array.reverse caching

### DIFF
--- a/dist/vtt.js
+++ b/dist/vtt.js
@@ -1518,21 +1518,28 @@
         cue = styleBox.cue,
         linePos = computeLinePos(cue),
         axis = [];
+        // Safari 12 introduced a bug where the reverse order of an array instantiated with primitives
+        // is cached after array.prototype.reverse is called (https://bugs.webkit.org/show_bug.cgi?id=188794).
+        // Variables are used as a workaround.
+        const posY = '+y';
+        const negY = '-y';
+        const posX = '+x';
+        const negX = '-x';
 
     // If we have a line number to align the cue to.
     if (cue.snapToLines) {
       var size;
       switch (cue.vertical) {
       case "":
-        axis = [ "+y", "-y" ];
+        axis = [posY, negY];
         size = "height";
         break;
       case "rl":
-        axis = [ "+x", "-x" ];
+        axis = [posX, negX];
         size = "width";
         break;
       case "lr":
-        axis = [ "-x", "+x" ];
+        axis = [negX, posX];
         size = "width";
         break;
       }
@@ -1595,7 +1602,7 @@
         break;
       }
 
-      axis = [ "+y", "-x", "+x", "-y" ];
+      axis = [posY, negX, posX, negY];
 
       // Get the box position again after we've applied the specified positioning
       // to it.


### PR DESCRIPTION
### This PR will...
use variables instead of strings when instantiating arrays that can be reversed.
### Why is this Pull Request needed?
Safari 12 introduced a bug where calling reverse on an array will cache the reverse value (https://bugs.webkit.org/show_bug.cgi?id=188794), causing captions to jump up and down.
To reproduce the bug run the following:
```
for (var i = 0; i <= 10; i ++) {
	var array1 = ['one', 'two'];
	console.log('array1: ', array1);
	var reversed = array1.reverse(); 
}
```
notice that even though the array is being instantiated, the value is reversed even before `reverse` is called.

The following screenshot shows the bug in action:
![wtf](https://user-images.githubusercontent.com/12138319/47315232-f94a8a00-d611-11e8-9978-ac2bf997101b.png)

