### PR TITLE
Safari 12 workaround for array.reverse caching

### DIFF
--- a/lib/vtt.js
+++ b/lib/vtt.js
@@ -925,7 +925,11 @@
       // video, depending on the writing direction, and reverse our axis directions.
       if (linePos < 0) {
         position += cue.vertical === "" ? containerBox.height : containerBox.width;
-        axis = axis.reverse();
+
+        // Safari 12 introduced a bug where the reverse order of an array is cached after calling
+        // array.prototype.reverse (https://bugs.webkit.org/show_bug.cgi?id=188794).
+        // As a workaround, call reverse on a copy of the 'axis' array, instead of calling it directly on the original var
+        axis = axis.slice().reverse();
       }
 
       // Move the box to the specified position. This may not be its best


### PR DESCRIPTION
### This PR will...
Reverse a copy of the axis array as a workaround for a bug introduced in Safari 12 (https://bugs.webkit.org/show_bug.cgi?id=188794)
### Why is this Pull Request needed?
Safari 12 introduced a bug where calling reverse on an array will cache the reverse value, causing captions to jump up and down.
To reproduce the bug run the following:
```
for (var i = 0; i <= 10; i ++) {
	var array1 = ['one', 'two'];
	console.log('array1: ', array1);
	var reversed = array1.reverse(); 
}
```
notice that even though the array is being instantiated, the value is reversed even before `reverse` is called.

The following screenshot shows the bug in action:
![wtf](https://user-images.githubusercontent.com/12138319/47315232-f94a8a00-d611-11e8-9978-ac2bf997101b.png)

